### PR TITLE
Hardware and Arduino Library Additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@
 - [Build a Colorviewer](https://wiki.odroid.com/odroid_go/arduino/36_colorview)
 - [Build an IR Receiver](https://wiki.odroid.com/odroid_go/arduino/37_ir_receiver)
 - [Make Arduino Applications](https://wiki.odroid.com/odroid_go/arduino_app)
+- [2.6" 320 x 240 - ILI9342 Libraries](https://github.com/gaboze-express/Odroid-GO-ILI9342)
 
 #### MicroPython
 - [Getting started with MicroPython](https://wiki.odroid.com/odroid_go/micropython/01_micropython_setup)

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@
 
 ### Projects
 
+#### Hardware
+> A List of Odroid-Go / ESP32 Hardware Projects
+
+- [Gaboze Express ](https://github.com/gaboze-express/GabozeExpress/tree/Hardware)
+  An ESP32 Wrover based Game Boy Pocket from the Makers of [Gaboze Pocaio](https://www.tindie.com/products/thirtytwoteeth/gaboze-pocaio-round-2/) this is an Odroid Go with a 2.6" 320 x 240 display, and drop in form factor of the Nintendo Game Boy Pocket, currently in final testing stages, contributors welcome
+
+
+
 #### Arduino
 - [Getting Started with Arduino](https://wiki.odroid.com/odroid_go/arduino/01_arduino_setup)
 - [Hello World](https://wiki.odroid.com/odroid_go/arduino/02_hello_world)


### PR DESCRIPTION
Added hardware section to projects

#### Hardware
> A List of Odroid-Go / ESP32 Hardware Projects

Added link to ILI9342 driver for Arduino

- [2.6" 320 x 240 - ILI9342 Libraries](https://github.com/gaboze-express/Odroid-GO-ILI9342)